### PR TITLE
Fix file opening mode (O_BINARY) in Windows in example application

### DIFF
--- a/src/navtex_rx_from_file.cpp
+++ b/src/navtex_rx_from_file.cpp
@@ -33,7 +33,11 @@ int main(int argc, const char** argv)
     if (argc == 2 || strcmp(argv[2], "-") == 0) {
         fd = fileno(stdin);
     } else {
-        fd = open(argv[2], O_RDONLY);
+        int flags = O_RDONLY;
+#ifdef O_BINARY
+        flags |= O_BINARY;
+#endif
+        fd = open(argv[2], flags);
         if (fd == -1) {
             fprintf(stderr, "open(%s) failed: %s\n", argv[2], strerror(errno));
             exit(EXIT_FAILURE);


### PR DESCRIPTION
In Windows, the `open` function by default processes the file in text mode, which does not allow to read the signal samples correctly. The corresponding O_BINARY flag has been added for those systems where it is defined 